### PR TITLE
Added include directories and linker dependencies for Win32 debug build.

### DIFF
--- a/encfs/encfs.vcxproj
+++ b/encfs/encfs.vcxproj
@@ -79,13 +79,14 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\;$(BOOST_ROOT)\includes\;$(OPENSSL_ROOT)\include;$(DOKAN_ROOT)\dokan_fuse\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalUsingDirectories>$(BOOST_ROOT)\includes\;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalIncludeDirectories>..\;$(OPENSSL_ROOT)\include;$(DOKAN_ROOT)\dokan_fuse\include;$(DOKAN_ROOT)\sys;..\deps\tinyxml2;..\deps\easyloggingpp\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;ENCFS_EXPORTS;RLOG_COMPONENT=rlog;_CRT_SECURE_NO_WARNINGS;DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>..\..\dokany-0.7.4\Win32\Debug\dokanfuse1.lib;..\..\openssl\lib\VC\libeay32MDd.lib;..\..\openssl\lib\VC\ssleay32MDd.lib;$(BOOST_ROOT)\lib32-msvc-14.0\libboost_filesystem-vc140-mt-gd-1_60.lib;$(BOOST_ROOT)\lib32-msvc-14.0\libboost_system-vc140-mt-gd-1_60.lib;$(BOOST_ROOT)\lib32-msvc-14.0\libboost_serialization-vc140-mt-gd-1_60.lib;..\rlog\Debug\*.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>$(DOKAN_ROOT)\Win32\Release\dokan1.lib;$(DOKAN_ROOT)\Win32\Release\dokanfuse1.lib;$(OPENSSL_ROOT)\lib\libeay32.lib;$(OPENSSL_ROOT)\lib\ssleay32.lib;..\deps\tinyxml2\tinyxml2\bin\Win32-Debug-Lib\tinyxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/encfs/encfs.vcxproj
+++ b/encfs/encfs.vcxproj
@@ -86,7 +86,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>$(DOKAN_ROOT)\Win32\Release\dokan1.lib;$(DOKAN_ROOT)\Win32\Release\dokanfuse1.lib;$(OPENSSL_ROOT)\lib\libeay32.lib;$(OPENSSL_ROOT)\lib\ssleay32.lib;..\deps\tinyxml2\tinyxml2\bin\Win32-Debug-Lib\tinyxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(DOKAN_ROOT)\Win32\Debug\dokan1.lib;$(DOKAN_ROOT)\Win32\Debug\dokanfuse1.lib;$(OPENSSL_ROOT)\lib\libeay32.lib;$(OPENSSL_ROOT)\lib\ssleay32.lib;..\deps\tinyxml2\tinyxml2\bin\Win32-Debug-Lib\tinyxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/encfs/encfsctl.vcxproj
+++ b/encfs/encfsctl.vcxproj
@@ -86,7 +86,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>$(DOKAN_ROOT)\Win32\Release\dokan1.lib;$(DOKAN_ROOT)\Win32\Release\dokanfuse1.lib;$(OPENSSL_ROOT)\lib\libeay32.lib;$(OPENSSL_ROOT)\lib\ssleay32.lib;..\deps\tinyxml2\tinyxml2\bin\Win32-Debug-Lib\tinyxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(DOKAN_ROOT)\Win32\Debug\dokan1.lib;$(DOKAN_ROOT)\Win32\Debug\dokanfuse1.lib;$(OPENSSL_ROOT)\lib\libeay32.lib;$(OPENSSL_ROOT)\lib\ssleay32.lib;..\deps\tinyxml2\tinyxml2\bin\Win32-Debug-Lib\tinyxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/encfs/encfsctl.vcxproj
+++ b/encfs/encfsctl.vcxproj
@@ -80,12 +80,13 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;ENCFS_EXPORTS;RLOG_COMPONENT=rlog-ctl;_CRT_SECURE_NO_WARNINGS;DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\;$(BOOST_ROOT)\includes\;$(OPENSSL_ROOT)\include;$(DOKAN_ROOT)\dokan_fuse\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalUsingDirectories>$(BOOST_ROOT)\includes\;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalIncludeDirectories>..\;$(OPENSSL_ROOT)\include;$(DOKAN_ROOT)\dokan_fuse\include;$(DOKAN_ROOT)\sys;..\deps\tinyxml2;..\deps\easyloggingpp\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>$(DOKAN_ROOT)\Win32\Release\dokan1.lib;$(DOKAN_ROOT)\Win32\Release\dokanfuse1.lib;$(OPENSSL_ROOT)\lib\libeay32.lib;$(OPENSSL_ROOT)\lib\ssleay32.lib;$(BOOST_ROOT)\lib32-msvc-14.0\libboost_filesystem-vc140-mt-1_60.lib;$(BOOST_ROOT)\lib32-msvc-14.0\libboost_system-vc140-mt-1_60.lib;$(BOOST_ROOT)\lib32-msvc-14.0\libboost_serialization-vc140-mt-1_60.lib;..\rlog\Release\*.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>$(DOKAN_ROOT)\Win32\Release\dokan1.lib;$(DOKAN_ROOT)\Win32\Release\dokanfuse1.lib;$(OPENSSL_ROOT)\lib\libeay32.lib;$(OPENSSL_ROOT)\lib\ssleay32.lib;..\deps\tinyxml2\tinyxml2\bin\Win32-Debug-Lib\tinyxml2.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/encfs/encfsw.vcxproj
+++ b/encfs/encfsw.vcxproj
@@ -60,11 +60,14 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalIncludeDirectories>.\;win\;..\;$(OPENSSL_ROOT)\include;$(DOKAN_ROOT)\dokan_fuse\include;$(DOKAN_ROOT)\sys;..\deps\tinyxml2;..\deps\easyloggingpp\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>$(DOKAN_ROOT)\Win32\Debug\dokan1.lib;$(DOKAN_ROOT)\Win32\Debug\dokanfuse1.lib;$(DOKAN_ROOT)\dokan_fuse\Win32\Debug\*.obj;$(OPENSSL_ROOT)\lib\libeay32.lib;$(OPENSSL_ROOT)\lib\ssleay32.lib;..\deps\tinyxml2\tinyxml2\bin\Win32-Debug-Lib\tinyxml2.lib;Debug\encfs\*.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
Edited the vcxproj files, so that a debug build of encfs4win can be made in the IDE. Note that debug versions of tinyxml and dokan must be built before building the encfs4win debug version.